### PR TITLE
fix: escape delimiters in substitution pattern, fix CI docs job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   stylua:
@@ -36,7 +39,8 @@ jobs:
           toc: true
           treesitter: true
           docmappingprojectname: false
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        if: github.ref == 'refs/heads/main'
         with:
           commit_message: "build(docs): auto generate vim documentation"
           commit_user_name: "github-actions[bot]"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ The following example shows the installation process using [lazy.nvim](https://g
 
 > [!TIP]
 > The word(s) being replaced during substitution are available in the replacement text using `&`.
-> 
+
+> [!NOTE]
+> The search pattern uses Vim's very magic mode (`\v`), so characters like `.`, `+`, `*`, and `()` are treated as regex operators. This lets you use regex in your search patterns without extra escaping. If you need to match these characters literally, escape them with `\` (e.g. `\.` to match a period).
+>
 ## Acknowledgments
 
 This project was inspired by [Scalpel](https://github.com/wincent/scalpel), a Vimscript plugin I've used for many years. **scalpel.nvim** is my version, which was reimagined and implemented in Lua for fun.

--- a/lua/scalpel/init.lua
+++ b/lua/scalpel/init.lua
@@ -64,7 +64,8 @@ function M.substitute()
   elseif is_blank(word) then
     vim.notify('Selection is blank, cannot substitute', vim.log.levels.INFO)
   else
-    local pattern = ':%s/\\v' .. word .. '//gc'
+    local escaped = vim.fn.escape(word, '/\\')
+    local pattern = ':%s/\\v' .. escaped .. '//gc'
     local cursor_move = vim.api.nvim_replace_termcodes('<Left><Left><Left>', true, false, true)
     vim.api.nvim_feedkeys(pattern .. cursor_move, 'n', true)
   end

--- a/tests/scalpel_spec.lua
+++ b/tests/scalpel_spec.lua
@@ -79,6 +79,31 @@ describe('scalpel', function()
       end)
     end)
 
+    describe('escaping', function()
+      it('escapes forward slashes in visual selection', function()
+        helpers.set_mode('v')
+        helpers.set_visual_marks({ 1, 0 }, { 1, 6 })
+        helpers.set_buffer_lines({ 'foo/bar baz' })
+
+        scalpel.substitute()
+
+        local call = helpers.feedkeys_calls[2]
+        assert.truthy(call.keys:find('foo\\/bar'))
+        assert.truthy(call.keys:find('//gc'))
+      end)
+
+      it('escapes backslashes in visual selection', function()
+        helpers.set_mode('v')
+        helpers.set_visual_marks({ 1, 0 }, { 1, 6 })
+        helpers.set_buffer_lines({ 'foo\\bar baz' })
+
+        scalpel.substitute()
+
+        local call = helpers.feedkeys_calls[2]
+        assert.truthy(call.keys:find('foo\\\\bar'))
+      end)
+    end)
+
     describe('visual mode', function()
       -- Note: get_visual_range() calls nvim_feedkeys with <Esc> first,
       -- so visual mode tests have an extra feedkeys call at index 1.


### PR DESCRIPTION
## Summary
- Fix bug where visual selections containing `/` or `\` corrupted the `:s` command delimiter structure by escaping with `vim.fn.escape()`
- Fix CI docs job: scope push triggers to `main`, add `refs/heads/main` guard on auto-commit, bump `git-auto-commit-action` to v5
- Add README note explaining the very magic (`\v`) regex design choice
- Add test cases for `/` and `\` escaping

## Test plan
- [x] All 15 tests pass locally (`make test`)
- [x] `make lint` passes
- [ ] CI build passes on GitHub Actions