### PR TITLE
feat: highlight matches immediately when substitution opens

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@
 
 [![build](https://github.com/wassimk/scalpel.nvim/actions/workflows/build.yml/badge.svg)](https://github.com/wassimk/scalpel.nvim/actions/workflows/build.yml) ![release](https://img.shields.io/github/v/release/wassimk/scalpel.nvim?logo=github)
 
+## Requirements
+
+- Neovim >= 0.10.0
+
 ## Installation
 
-Install **scalpel.nvim** with your preferred plugin manager. 
+Install **scalpel.nvim** with your preferred plugin manager.
 
 The following example shows the installation process using [lazy.nvim](https://github.com/folke/lazy.nvim). It sets the scalpel substitute keymap to `<leader>e`.
 
@@ -35,31 +39,37 @@ The following example shows the installation process using [lazy.nvim](https://g
 
 ## Usage
 
-#### Normal Mode
+### Normal Mode
 
 1. Move the cursor over the word to replace
 2. Trigger the substitution with your keymap
 3. Begin typing the desired substitution and hit return
 
-#### Visual Mode
+All occurrences of the word in the buffer are highlighted and the substitution command is pre-filled with the word under the cursor.
+
+### Visual Mode
 
 1. Use visual mode (`v`) to select the word(s) to replace within a *single line*
 2. Trigger the substitution with your keymap
 3. Begin typing the desired substitution and hit return
 
-#### Visual Line Mode
+All occurrences of the selected text in the buffer are highlighted and the substitution command is pre-filled with the selection.
 
-1. Highlight word(s) to substitute with `*` or `/`
-2. Use visual line mode (`V`) to highlight the lines with the word(s) to substitute
+### Visual Line Mode
+
+1. Search for the word(s) to substitute with `*` or `/`
+2. Use visual line mode (`V`) to highlight the lines to scope the substitution to
 3. Trigger the substitution with your keymap
 4. Begin typing the desired substitution and hit return
+
+The substitution reuses your last search pattern and is scoped to the selected lines. The cursor is positioned in the replacement field so you can type the replacement immediately.
 
 > [!TIP]
 > The word(s) being replaced during substitution are available in the replacement text using `&`.
 
 > [!NOTE]
 > The search pattern uses Vim's very magic mode (`\v`), so characters like `.`, `+`, `*`, and `()` are treated as regex operators. This lets you use regex in your search patterns without extra escaping. If you need to match these characters literally, escape them with `\` (e.g. `\.` to match a period).
->
+
 ## Acknowledgments
 
 This project was inspired by [Scalpel](https://github.com/wincent/scalpel), a Vimscript plugin I've used for many years. **scalpel.nvim** is my version, which was reimagined and implemented in Lua for fun.

--- a/lua/scalpel/init.lua
+++ b/lua/scalpel/init.lua
@@ -65,6 +65,7 @@ function M.substitute()
     vim.notify('Selection is blank, cannot substitute', vim.log.levels.INFO)
   else
     local escaped = vim.fn.escape(word, '/\\')
+    vim.fn.setreg('/', '\\v' .. escaped)
     local pattern = ':%s/\\v' .. escaped .. '//gc'
     local cursor_move = vim.api.nvim_replace_termcodes('<Left><Left><Left>', true, false, true)
     vim.api.nvim_feedkeys(pattern .. cursor_move, 'n', true)

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -3,6 +3,8 @@ local M = {}
 -- Tracked values
 M.feedkeys_calls = {}
 M.notifications = {}
+M.last_setreg_name = nil
+M.last_setreg_value = nil
 
 -- Original functions
 local originals = {}
@@ -10,9 +12,12 @@ local originals = {}
 function M.setup_mocks()
   M.feedkeys_calls = {}
   M.notifications = {}
+  M.last_setreg_name = nil
+  M.last_setreg_value = nil
 
   originals.mode = vim.fn.mode
   originals.expand = vim.fn.expand
+  originals.setreg = vim.fn.setreg
   originals.feedkeys = vim.api.nvim_feedkeys
   originals.replace_termcodes = vim.api.nvim_replace_termcodes
   originals.buf_get_mark = vim.api.nvim_buf_get_mark
@@ -26,6 +31,11 @@ function M.setup_mocks()
 
   vim.fn.expand = function()
     return 'word'
+  end
+
+  vim.fn.setreg = function(name, value)
+    M.last_setreg_name = name
+    M.last_setreg_value = value
   end
 
   vim.api.nvim_feedkeys = function(keys, mode, escape_ks)
@@ -80,6 +90,7 @@ end
 function M.teardown_mocks()
   vim.fn.mode = originals.mode
   vim.fn.expand = originals.expand
+  vim.fn.setreg = originals.setreg
   vim.api.nvim_feedkeys = originals.feedkeys
   vim.api.nvim_replace_termcodes = originals.replace_termcodes
   vim.api.nvim_buf_get_mark = originals.buf_get_mark

--- a/tests/scalpel_spec.lua
+++ b/tests/scalpel_spec.lua
@@ -56,6 +56,16 @@ describe('scalpel', function()
         assert.truthy(call.keys:find('<Left><Left><Left>'))
       end)
 
+      it('sets the search register for hlsearch highlighting', function()
+        helpers.set_mode('n')
+        helpers.set_expand('hello')
+
+        scalpel.substitute()
+
+        assert.equals('/', helpers.last_setreg_name)
+        assert.equals('\\vhello', helpers.last_setreg_value)
+      end)
+
       it('notifies when word is blank', function()
         helpers.set_mode('n')
         helpers.set_expand('   ')
@@ -120,6 +130,17 @@ describe('scalpel', function()
         assert.truthy(call.keys:find('hello'))
         assert.truthy(call.keys:find(':%%s/\\v'))
         assert.truthy(call.keys:find('//gc'))
+      end)
+
+      it('sets the search register for hlsearch highlighting', function()
+        helpers.set_mode('v')
+        helpers.set_visual_marks({ 1, 4 }, { 1, 8 })
+        helpers.set_buffer_lines({ 'the hello world line' })
+
+        scalpel.substitute()
+
+        assert.equals('/', helpers.last_setreg_name)
+        assert.equals('\\vhello', helpers.last_setreg_value)
       end)
 
       it('extracts correct substring from line', function()
@@ -188,6 +209,14 @@ describe('scalpel', function()
         scalpel.substitute()
 
         assert.equals(0, #helpers.notifications)
+      end)
+
+      it('does not set the search register', function()
+        helpers.set_mode('V')
+
+        scalpel.substitute()
+
+        assert.is_nil(helpers.last_setreg_name)
       end)
     end)
   end)


### PR DESCRIPTION
## Summary
- Set the search register (`@/`) before feeding the `:s` command so `hlsearch` highlights all matches as soon as the command line appears
- Clean up README: add requirements section, fix heading levels (`###` instead of `####`), add descriptions below each mode explaining the behavior, clarify the visual line mode workflow, fix trailing `>` on the `\v` note

## Test plan
- [x] All 18 tests pass locally (`make test`)
- [x] `make lint` passes
- [ ] CI passes
- [ ] Manual: trigger substitution in normal mode — matches should highlight immediately
- [ ] Manual: trigger substitution in visual mode — matches should highlight immediately