### PR TITLE
ci: remove vimdoc job from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,23 +27,3 @@ jobs:
           neovim: true
           version: v0.10.0
       - run: make test
-  docs:
-    name: vimdoc
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: kdheepak/panvimdoc@main
-        with:
-          vimdoc: scalpel.nvim
-          version: "NVIM v0.10.0"
-          toc: true
-          treesitter: true
-          docmappingprojectname: false
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        if: github.ref == 'refs/heads/main'
-        with:
-          commit_message: "build(docs): auto generate vim documentation"
-          commit_user_name: "github-actions[bot]"
-          commit_user_email: "github-actions[bot]@users.noreply.github.com"
-          commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
-          branch: "main"


### PR DESCRIPTION
## Summary
- Remove the CI vimdoc job since generation is now handled locally via the pre-commit hook added in #10

## Test plan
- [x] CI passes with only stylua and test jobs remaining